### PR TITLE
Skip tests which rely on a database so this builds on R universe

### DIFF
--- a/fakerbase.Rproj
+++ b/fakerbase.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-db-integration.R
+++ b/tests/testthat/test-db-integration.R
@@ -1,4 +1,5 @@
 test_that("can generate from db", {
+  testthat::skip_on_cran()
   con <- DBI::dbConnect(RPostgres::Postgres(),
                         dbname = "northwind",
                         host = "localhost",
@@ -19,6 +20,7 @@ test_that("can generate from db", {
 })
 
 test_that("can generate and load from package", {
+  testthat::skip_on_cran()
   con <- DBI::dbConnect(RPostgres::Postgres(),
                         dbname = "northwind",
                         host = "localhost",
@@ -39,6 +41,7 @@ test_that("can generate and load from package", {
 })
 
 test_that("throws error if provided package_path does not point to a package", {
+  testthat::skip_on_cran()
   con <- DBI::dbConnect(RPostgres::Postgres(),
                         dbname = "northwind",
                         host = "localhost",
@@ -51,6 +54,7 @@ test_that("throws error if provided package_path does not point to a package", {
 })
 
 test_that("can generate and load from absolute path", {
+  testthat::skip_on_cran()
   con <- DBI::dbConnect(RPostgres::Postgres(),
                         dbname = "northwind",
                         host = "localhost",
@@ -64,6 +68,7 @@ test_that("can generate and load from absolute path", {
 })
 
 test_that("loading un-generated functions gives descriptive error message", {
+  testthat::skip_on_cran()
   con <- DBI::dbConnect(RPostgres::Postgres(),
                         dbname = "northwind",
                         host = "localhost",


### PR DESCRIPTION
Our orderly image builds are regularly failing due to github API rate limit issues (e.g. https://buildkite.com/mrc-ide/orderly-dot-server/builds/792) so we need an alternative way to install packages. We want to use R universe but that builds the packages as CRAN would including running R CMD check. See https://github.com/r-universe/mrc-ide/runs/7655030651?check_suite_focus=true#step:35:83 for the failed build . We need to skip tests which rely on some additional setup as package build process is not customisable https://github.com/r-universe-org/help#is-it-possible-to-customize-the-package-build-process-with-custom-optionstoolsvariables